### PR TITLE
Refactor main window structure

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,14 @@
+"""Entry point for launching the ForTeraterm application."""
+
 from ForTeraterm.main_menu import Mainmenu
 
-def main():
-    mm = Mainmenu()
+
+def main() -> None:
+    """Instantiate and run the main application window."""
+
+    app = Mainmenu()
+    app.run()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- refactor the Mainmenu class to separate window construction from the Tk main loop
- replace wildcard imports with explicit dependencies and add type hints and documentation
- improve README opening logic and remove duplicate frame management logic

## Testing
- `python -m compileall ForTeraterm main.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915cd6f69e8832c9c2b36cc113eb439)