### PR TITLE
Track and document current frame lifecycle

### DIFF
--- a/ForTeraterm/main_menu.py
+++ b/ForTeraterm/main_menu.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, List, Optional, Sequence, Tuple
+from typing import Callable, Optional, Sequence, Tuple
 import webbrowser
 
 import customtkinter
@@ -35,7 +35,7 @@ class Mainmenu(customtkinter.CTk):
         self.apptxt = AppText(appconf.get_data("lang"))
         self._theme = ThemeManager()
         self._content_frame: ThemeFrame1 | None = None
-        self._sub_frames: List[customtkinter.CTkFrame] = []
+        self._current_frame: customtkinter.CTkFrame | None = None
 
         self._configure_window()
         self._build_menu_bar()
@@ -138,7 +138,7 @@ class Mainmenu(customtkinter.CTk):
 
         self.reset_frame()
         frame = factory(self._content_frame)
-        self._sub_frames.append(frame)
+        self._current_frame = frame
 
     @appconf.log_exception
     def action_serveraccess(self) -> None:
@@ -159,9 +159,9 @@ class Mainmenu(customtkinter.CTk):
     def reset_frame(self) -> None:
         """Clear existing frames from the content area."""
 
-        for frame in self._sub_frames:
-            frame.destroy()
-        self._sub_frames.clear()
+        if self._current_frame is not None:
+            self._current_frame.destroy()
+            self._current_frame = None
 
     @appconf.log_exception
     def about_readme(self) -> None:

--- a/docs/frame_management.md
+++ b/docs/frame_management.md
@@ -1,0 +1,60 @@
+# Frame lifecycle scenarios and verification
+
+このドキュメントでは、`Mainmenu` 内で `_current_frame` を導入した後の想定シナリオと、
+フレーム破棄の手動確認手順をまとめます。
+
+## 操作シナリオ
+
+- **初期表示**
+  - アプリ起動時 (`Mainmenu.__init__`) に `action_serveraccess()` が呼び出され、`_current_frame` が
+    `ServerAccess` フレームで初期化される。
+  - `_current_frame` が `None` から実フレームに遷移し、表示中フレームは常に 1 つだけとなる。
+- **別メニューへ切り替え**
+  - メニューバーから `EditMacro` や `ServerRegist` を選択すると `_show_frame()` が呼び出される。
+  - `_show_frame()` はまず `reset_frame()` を実行し、既存の `_current_frame` を破棄した後で新しい
+    フレームを生成して `_current_frame` に保存する。
+  - 破棄済みフレームは `_current_frame` から切り離され、再利用されない。
+- **同一メニューの再表示**
+  - 既に表示済みのメニューを再度選択した場合でも、`reset_frame()` が実行されて旧フレームが破棄される。
+  - その後新しいフレームが生成されるため、表示内容が最新状態に保たれ、旧ウィジェットが残存しない。
+- **設定ダイアログなどの他カテゴリ**
+  - `Settings` → `Edit` のように異なるカテゴリでも同様に `_current_frame` が再生成される。
+  - これにより、どのメニューを経由しても画面に複数フレームが積み重なることはない。
+
+## 手動テスト手順
+
+事前に `python -i main.py` でアプリを起動すると、GUI を操作しながら Python REPL から内部状態を
+確認できます。
+
+1. **初期状態の確認**
+   1. GUI が表示されたら REPL で `app._content_frame.winfo_children()` を実行し、戻り値の長さが `1`
+      であることを確認する。
+   2. `app._current_frame` が `None` ではなく、表示中フレームのインスタンスであることを確認する。
+2. **メニュー切り替えの確認**
+   1. GUI で `Action` → `EditMacro` を選択する。
+   2. REPL で `app._content_frame.winfo_children()` の長さが再び `1` であること、
+      `app._current_frame` が新しいフレームに置き換わっていることを確認する。
+3. **同一メニューの再選択**
+   1. 再度 `Action` → `EditMacro` を選択する。
+   2. REPL で `app._current_frame` の `destroy` メソッドが一度だけ呼び出されていることを
+      ログまたはデバッガで確認する（`print` でフックする場合は次の例を参照）。
+4. **破棄済みフレームの残存確認**
+   1. 任意のメニューを複数回切り替えた後でも `app._content_frame.winfo_children()` の長さが `1`
+      から変化しないことを確認する。
+   2. `app._current_frame` の `winfo_exists()` を呼び出し、`1` が返るのは表示中のフレームのみであることを確認する。
+
+### destroy 呼び出し回数を可視化する例
+
+```
+original_reset = app.reset_frame
+
+def wrapped_reset():
+    if app._current_frame is not None:
+        print("destroy target:", type(app._current_frame).__name__)
+    original_reset()
+
+app.reset_frame = wrapped_reset
+```
+
+上記のように `reset_frame()` を一時的にラップすると、GUI 操作に合わせて破棄対象が 1 つずつ出力
+され、破棄済みフレームが再利用されていないことを確認できます。

--- a/tests/test_mainmenu_frames.py
+++ b/tests/test_mainmenu_frames.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Callable
+
+customtkinter_stub = types.ModuleType("customtkinter")
+
+
+class _CTk:
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - stub
+        _ = (args, kwargs)
+
+
+class _CTkFrame:
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - stub
+        _ = (args, kwargs)
+
+    def destroy(self) -> None:  # pragma: no cover - stub
+        pass
+
+
+class _CTkButton(_CTkFrame):
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - stub
+        super().__init__(*args, **kwargs)
+
+
+def _set_appearance_mode(mode: str) -> None:  # pragma: no cover - stub
+    _ = mode
+
+
+customtkinter_stub.CTk = _CTk
+customtkinter_stub.CTkFrame = _CTkFrame
+customtkinter_stub.CTkButton = _CTkButton
+customtkinter_stub.set_appearance_mode = _set_appearance_mode
+
+sys.modules.setdefault("customtkinter", customtkinter_stub)
+
+
+ctk_menu_bar_stub = types.ModuleType("ForTeraterm.CTkMenuBar")
+
+
+class _CascadeButton:
+    def __init__(self) -> None:
+        self.label: str | None = None
+
+
+class _CTkMenuBar:
+    def __init__(self, master) -> None:  # pragma: no cover - stub
+        self.master = master
+
+    def add_cascade(self, label: str) -> _CascadeButton:  # pragma: no cover - stub
+        button = _CascadeButton()
+        button.label = label
+        return button
+
+
+class _CustomDropdownMenu:
+    def __init__(self, widget, **kwargs) -> None:  # pragma: no cover - stub
+        self.widget = widget
+        self.options: list[tuple[str, Callable[[], None]]] = []
+        _ = kwargs
+
+    def add_option(self, option: str, command: Callable[[], None]) -> None:  # pragma: no cover - stub
+        self.options.append((option, command))
+
+
+ctk_menu_bar_stub.CTkMenuBar = _CTkMenuBar
+ctk_menu_bar_stub.CustomDropdownMenu = _CustomDropdownMenu
+
+sys.modules.setdefault("ForTeraterm.CTkMenuBar", ctk_menu_bar_stub)
+
+
+language_stub = types.ModuleType("ForTeraterm.Language.apptext")
+
+
+class _AppText:
+    def __init__(self, lang: str) -> None:  # pragma: no cover - stub
+        self.lang = lang
+
+    def translate(self, key: str) -> str:  # pragma: no cover - stub
+        return key
+
+
+language_stub.AppText = _AppText
+sys.modules.setdefault("ForTeraterm.Language.apptext", language_stub)
+
+
+window_theme_stub = types.ModuleType("ForTeraterm.WindowSettings.theme")
+
+
+class _ThemeFrame1(_CTkFrame):
+    pass
+
+
+class _ThemeManager:
+    def __init__(self) -> None:  # pragma: no cover - stub
+        self.mode = "Light"
+        self.back1 = "#fff"
+        self.back2 = "#000"
+        self.setfont = ("Arial", 12)
+        self.highlight = "#f00"
+
+
+window_theme_stub.ThemeFrame1 = _ThemeFrame1
+window_theme_stub.ThemeManager = _ThemeManager
+sys.modules.setdefault("ForTeraterm.WindowSettings.theme", window_theme_stub)
+
+
+window_conf_stub = types.ModuleType("ForTeraterm.WindowSettings.conf")
+
+
+class _AppConf:
+    __name__ = "appconf"
+    __version__ = "0"
+    __license__ = "MIT"
+
+    def get_data(self, key: str) -> int | str:
+        defaults: dict[str, int | str] = {
+            "lang": "en",
+            "width": 800,
+            "height": 600,
+            "dev_mode": 0,
+        }
+        return defaults[key]
+
+    def log_exception(self, func: Callable) -> Callable:
+        return func
+
+
+window_conf_stub.appconf = _AppConf()
+sys.modules.setdefault("ForTeraterm.WindowSettings.conf", window_conf_stub)
+
+
+window_edit_stub = types.ModuleType("ForTeraterm.WindowSettings.edit")
+
+
+class _Edit(_ThemeFrame1):
+    def __init__(self, master) -> None:  # pragma: no cover - stub
+        super().__init__(master)
+
+
+window_edit_stub.Edit = _Edit
+sys.modules.setdefault("ForTeraterm.WindowSettings.edit", window_edit_stub)
+
+
+window_action_stub = types.ModuleType("ForTeraterm.WindowAction.serveraccess")
+
+
+class _ServerAccess(_ThemeFrame1):
+    def __init__(self, master) -> None:  # pragma: no cover - stub
+        super().__init__(master)
+
+
+window_action_stub.ServerAccess = _ServerAccess
+sys.modules.setdefault("ForTeraterm.WindowAction.serveraccess", window_action_stub)
+
+
+server_regist_stub = types.ModuleType("ForTeraterm.WindowAction.serverregist")
+
+
+class _ServerRegist(_ThemeFrame1):
+    def __init__(self, master) -> None:  # pragma: no cover - stub
+        super().__init__(master)
+
+
+server_regist_stub.ServerRegist = _ServerRegist
+sys.modules.setdefault("ForTeraterm.WindowAction.serverregist", server_regist_stub)
+
+
+edit_macro_stub = types.ModuleType("ForTeraterm.WindowAction.editmacro")
+
+
+class _EditMacro(_ThemeFrame1):
+    def __init__(self, master) -> None:  # pragma: no cover - stub
+        super().__init__(master)
+
+
+edit_macro_stub.EditMacro = _EditMacro
+sys.modules.setdefault("ForTeraterm.WindowAction.editmacro", edit_macro_stub)
+
+
+messsagebox_stub = types.ModuleType("ForTeraterm.util.messsagebox")
+
+
+def _show_info(*args, **kwargs) -> None:  # pragma: no cover - stub
+    _ = (args, kwargs)
+
+
+def _show_warning(*args, **kwargs) -> None:  # pragma: no cover - stub
+    _ = (args, kwargs)
+
+
+messsagebox_stub.show_info = _show_info
+messsagebox_stub.show_warning = _show_warning
+sys.modules.setdefault("ForTeraterm.util.messsagebox", messsagebox_stub)
+
+
+from ForTeraterm.main_menu import Mainmenu
+
+
+class DummyFrame:
+    def __init__(self) -> None:
+        self.destroy_calls = 0
+
+    def destroy(self) -> None:
+        self.destroy_calls += 1
+
+
+def test_reset_frame_destroys_current_frame_once() -> None:
+    menu = Mainmenu.__new__(Mainmenu)
+    dummy = DummyFrame()
+    menu._current_frame = dummy  # type: ignore[attr-defined]
+
+    Mainmenu.reset_frame(menu)
+    assert menu._current_frame is None  # type: ignore[attr-defined]
+    assert dummy.destroy_calls == 1
+
+    Mainmenu.reset_frame(menu)
+    assert dummy.destroy_calls == 1


### PR DESCRIPTION
## Summary
- replace the sub-frame list with a `_current_frame` slot so each menu change destroys the previous view before loading the next one
- document the expected frame lifecycle scenarios and add a manual regression checklist for verifying no stale frames remain
- add a regression test that stubs out UI dependencies and asserts `reset_frame()` only destroys the active frame once

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ccf8bd6c832ca5ed3339a022a93e)