### PR TITLE
Document open_file_dialog initialdir handling and add tests

### DIFF
--- a/ForTeraterm/WindowAction/serverregist.py
+++ b/ForTeraterm/WindowAction/serverregist.py
@@ -968,10 +968,17 @@ class ServerRegist(ThemeFrame1):
     
     @staticmethod
     def open_file_dialog(filetypes,initialdir):
-        # Open a file dialog and get the selected file path
-        # [('data files','*.csv;*.txt')]
+        """Open a file dialog and get the selected file path.
+
+        Accepts ``str``, :class:`pathlib.Path`, or ``None`` for ``initialdir``.
+        Any :class:`pathlib.Path` value is converted to ``str`` before the
+        underlying dialog is invoked so callers do not need to perform the
+        conversion themselves.
+        """
+
+        if initialdir is not None:
+            initialdir = os.fspath(initialdir)
         file_path = filedialog.askopenfilename(filetypes=filetypes,initialdir=initialdir)
         if file_path:
             return file_path
         return None
-    

--- a/ForTeraterm/WindowSettings/edit.py
+++ b/ForTeraterm/WindowSettings/edit.py
@@ -311,8 +311,15 @@ class Edit(ThemeFrame1):
     
     @staticmethod
     def open_file_dialog(filetypes,initialdir):
-        # Open a file dialog and get the selected file path
-        # [('data files','*.csv;*.txt')]
+        """Open a file dialog and get the selected file path.
+
+        The ``initialdir`` argument accepts ``str``, :class:`pathlib.Path`, or
+        ``None`` values; :class:`pathlib.Path` objects are converted to strings
+        before calling :func:`tkinter.filedialog.askopenfilename`.
+        """
+
+        if initialdir is not None:
+            initialdir = os.fspath(initialdir)
         file_path = filedialog.askopenfilename(filetypes=filetypes,initialdir=initialdir)
         if file_path:
             return file_path

--- a/ForTeraterm/main_menu.py
+++ b/ForTeraterm/main_menu.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
+from os import fspath
 import webbrowser
 
 import customtkinter
@@ -202,8 +203,22 @@ class Mainmenu(customtkinter.CTk):
         filetypes: Sequence[tuple[str, str]] | None,
         initialdir: str | Path | None,
     ) -> Optional[str]:
-        """Open a file selection dialog and return the chosen file path."""
+        """Open a file selection dialog.
 
+        Args:
+            filetypes: File type filters passed directly to
+                :func:`tkinter.filedialog.askopenfilename`.
+            initialdir: Starting directory for the dialog.  Accepts ``str`` or
+                :class:`pathlib.Path` objects as well as ``None``; any
+                :class:`pathlib.Path` values are converted to strings before
+                invoking the dialog.
+
+        Returns:
+            The selected file path or ``None`` if the dialog is cancelled.
+        """
+
+        if initialdir is not None:
+            initialdir = fspath(initialdir)
         file_path = filedialog.askopenfilename(
             filetypes=filetypes,
             initialdir=initialdir,

--- a/tests/test_file_dialog.py
+++ b/tests/test_file_dialog.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+if "customtkinter" not in sys.modules:
+    class _DummyCustomTkModule(types.ModuleType):
+        def __getattr__(self, name: str):  # pragma: no cover - fallback for unneeded attributes
+            dummy_type = type(name, (), {"__init__": lambda self, *args, **kwargs: None})
+            setattr(self, name, dummy_type)
+            return dummy_type
+
+    mock_customtkinter = _DummyCustomTkModule("customtkinter")
+
+    def _dummy_set_appearance_mode(*args, **kwargs) -> None:  # pragma: no cover - trivial stub
+        pass
+
+    mock_customtkinter.set_appearance_mode = _dummy_set_appearance_mode
+    sys.modules["customtkinter"] = mock_customtkinter
+
+
+if "ForTeraterm.CTkMessagebox" not in sys.modules:
+    messagebox_pkg = types.ModuleType("ForTeraterm.CTkMessagebox")
+    sys.modules["ForTeraterm.CTkMessagebox"] = messagebox_pkg
+
+    messagebox_mod = types.ModuleType("ForTeraterm.CTkMessagebox.ctkmessagebox")
+
+    class _DummyCTkMessagebox:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    messagebox_mod.CTkMessagebox = _DummyCTkMessagebox
+    sys.modules["ForTeraterm.CTkMessagebox.ctkmessagebox"] = messagebox_mod
+    messagebox_pkg.ctkmessagebox = messagebox_mod
+
+
+if "PIL" not in sys.modules:
+    pil_pkg = types.ModuleType("PIL")
+    sys.modules["PIL"] = pil_pkg
+
+    pil_image = types.ModuleType("PIL.Image")
+
+    pil_image.open = lambda *args, **kwargs: RuntimeError("Image.open stub should not be called during tests")
+    sys.modules["PIL.Image"] = pil_image
+    pil_pkg.Image = pil_image
+
+
+stub_image_module = types.ModuleType("ForTeraterm.WindowSettings.image")
+
+
+class _DummyImgInst:
+    def __getattr__(self, name):  # pragma: no cover - fallback for unused attributes
+        return None
+
+
+stub_image_module.imginst = _DummyImgInst()
+sys.modules["ForTeraterm.WindowSettings.image"] = stub_image_module
+
+
+if "pyautogui" not in sys.modules:
+    sys.modules["pyautogui"] = types.ModuleType("pyautogui")
+
+
+from ForTeraterm.main_menu import Mainmenu
+
+
+@pytest.fixture
+def fake_askopenfilename(monkeypatch):
+    """Capture calls to ``filedialog.askopenfilename`` for assertions."""
+
+    calls: list[dict[str, object]] = []
+
+    def stub(*, filetypes, initialdir):
+        calls.append({"filetypes": filetypes, "initialdir": initialdir})
+        return "selected-file"
+
+    monkeypatch.setattr("ForTeraterm.main_menu.filedialog.askopenfilename", stub)
+    return calls
+
+
+def test_open_file_dialog_accepts_str_initialdir(fake_askopenfilename):
+    filetypes = [("All", "*.*")]
+    result = Mainmenu.open_file_dialog(filetypes, "C:/tmp")
+
+    assert result == "selected-file"
+    (call,) = fake_askopenfilename
+    assert call["filetypes"] is filetypes
+    assert call["initialdir"] == "C:/tmp"
+
+
+def test_open_file_dialog_accepts_path_initialdir(fake_askopenfilename):
+    filetypes = [("All", "*.*")]
+    initialdir = Path("/path/dir")
+
+    Mainmenu.open_file_dialog(filetypes, initialdir)
+
+    (call,) = fake_askopenfilename
+    assert call["initialdir"] == str(initialdir)
+
+
+def test_open_file_dialog_accepts_none_initialdir(monkeypatch):
+    def stub(*, filetypes, initialdir):
+        assert initialdir is None
+        return ""
+
+    monkeypatch.setattr("ForTeraterm.main_menu.filedialog.askopenfilename", stub)
+
+    result = Mainmenu.open_file_dialog([("All", "*.*")], None)
+
+    assert result is None


### PR DESCRIPTION
## Summary
- document the supported types for the `open_file_dialog` helper and convert `Path` inputs to strings before invoking Tk dialogs
- apply the same conversion behavior to the settings and server registration dialogs to avoid caller changes
- add unit tests that patch Tk file dialogs to verify `initialdir` handling for `str`, `Path`, and `None`

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ccfcbc24832cb035aa65d166cc33)