### PR TITLE
Add GitHub Actions workflow for automated build and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pyinstaller customtkinter pillow pyautogui pyinstaller-hooks-contrib
+
+      - name: Run tests
+        shell: pwsh
+        run: pytest
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+
+      - name: Build application
+        shell: pwsh
+        run: |
+          pyinstaller main.spec
+          New-Item -ItemType Directory -Path dist/main/img -Force | Out-Null
+          New-Item -ItemType Directory -Path dist/main/locales -Force | Out-Null
+          New-Item -ItemType Directory -Path dist/main/icons -Force | Out-Null
+          Copy-Item -Path img\* -Destination dist/main/img/ -Recurse -Force
+          Copy-Item -Path locales\* -Destination dist/main/locales/ -Recurse -Force
+          Copy-Item -Path icons\* -Destination dist/main/icons/ -Recurse -Force
+          Copy-Item -Path README.pdf -Destination dist/main/ -Force
+          python write_mkinstiss.py
+          & "C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe" mkinst.iss
+
+      - name: Create archives
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path release -Force | Out-Null
+          Compress-Archive -Path dist/main/* -DestinationPath "release/ForTeraterm-$env:GITHUB_REF_NAME.zip" -Force
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ForTeraterm-${{ github.ref_name }}
+          path: |
+            release/ForTeraterm-${{ github.ref_name }}.zip
+            Output/SetupForTeraterm.exe
+
+      - name: Publish release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            release/ForTeraterm-${{ github.ref_name }}.zip
+            Output/SetupForTeraterm.exe


### PR DESCRIPTION
## Summary
- add a Windows GitHub Actions workflow that runs tests and packages the application with PyInstaller
- bundle static assets, generate the Inno Setup installer, and archive the outputs for releases
- publish tagged builds automatically as GitHub release assets

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917d0abae60832cbde51a051d5c7c76)