### PR TITLE
Provide fallback message box when CTkMessagebox submodule is missing

### DIFF
--- a/ForTeraterm/util/messsagebox.py
+++ b/ForTeraterm/util/messsagebox.py
@@ -1,4 +1,104 @@
-from ..CTkMessagebox.ctkmessagebox import CTkMessagebox
+"""Utilities for showing user-facing message boxes.
+
+The project bundles the third-party ``CTkMessagebox`` widget as a Git
+submodule.  When the submodule is missing (for example because the repository
+was cloned without ``--recursive``) importing the widget raises
+``ModuleNotFoundError`` and prevents the application from launching.  The
+fallback implementation below emulates the small subset of behaviour required by
+the application so the program remains usable even without the optional
+dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+try:
+    from ..CTkMessagebox.ctkmessagebox import CTkMessagebox
+except ModuleNotFoundError:  # pragma: no cover - exercised when submodule missing
+    import contextlib
+
+    try:  # ``tkinter`` may be unavailable in some environments (e.g. minimal CI)
+        import tkinter as tk
+        from tkinter import messagebox
+    except Exception:  # pragma: no cover - triggered only if tkinter is missing
+        tk = None  # type: ignore[assignment]
+        messagebox = None  # type: ignore[assignment]
+
+    class CTkMessagebox:  # type: ignore[override]
+        """Minimal stand-in for the optional CTkMessagebox dependency."""
+
+        _root: Optional["tk.Tk"] = None
+
+        def __init__(
+            self,
+            *,
+            title: str = "Info",
+            message: str = "",
+            icon: Optional[str] = None,
+            option_1: Optional[str] = "OK",
+            option_2: Optional[str] = None,
+            option_3: Optional[str] = None,
+        ) -> None:
+            self._response = option_1
+
+            if tk is None or messagebox is None:
+                self._fallback_to_console(title, message)
+                return
+
+            try:
+                root = self._ensure_root()
+                self._response = self._show_message(
+                    root, title, message, icon, option_1, option_2, option_3
+                )
+            except tk.TclError:
+                self._fallback_to_console(title, message)
+
+        @classmethod
+        def _ensure_root(cls) -> "tk.Tk":
+            if cls._root is None:
+                root = tk.Tk()
+                root.withdraw()
+                with contextlib.suppress(AttributeError):
+                    root.report_callback_exception = lambda *_, **__: None
+                cls._root = root
+            return cls._root
+
+        def _show_message(
+            self,
+            root: "tk.Tk",
+            title: str,
+            message: str,
+            icon: Optional[str],
+            option_1: Optional[str],
+            option_2: Optional[str],
+            option_3: Optional[str],
+        ) -> Optional[str]:
+            if icon == "warning" and option_2 and option_3 is None:
+                retry = messagebox.askretrycancel(title, message, master=root)
+                return option_2 if retry else option_1
+
+            if icon == "question":
+                result = messagebox.askyesnocancel(title, message, master=root)
+                if result is True and option_3 is not None:
+                    return option_3
+                if result is False and option_2 is not None:
+                    return option_2
+                return option_1
+
+            if icon in {"cancel", "error"}:
+                messagebox.showerror(title, message, master=root)
+                return option_1
+
+            messagebox.showinfo(title, message, master=root)
+            return option_1
+
+        @staticmethod
+        def _fallback_to_console(title: str, message: str) -> None:
+            print(f"[{title}] {message}")
+
+        def get(self) -> Optional[str]:
+            return self._response
 
 def show_info(title="Info", message="This is a CTkMessagebox!"):
     # Default messagebox for showing some information


### PR DESCRIPTION
## Summary
- add a tkinter-backed fallback CTkMessagebox implementation when the git submodule is unavailable
- ensure the application can still display basic message boxes and recover gracefully if tkinter is not usable

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185aa7d460832ca6037eb5aa967ab1)