### PR TITLE
Fix release workflow artifact naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,17 @@ jobs:
         run: |
           New-Item -ItemType Directory -Path release -Force | Out-Null
           $tag = "${{ github.ref_name }}"         # v1.0.4
-          $ver = $tag.TrimStart("v")              # 1.0.4
-          Compress-Archive -Path dist/main/* -DestinationPath "release/ForTeraterm-$ver.zip" -Force
+          $archivePath = "release/ForTeraterm-$tag.zip"
+
+          Compress-Archive -Path dist/main/* -DestinationPath $archivePath -Force
+
+          $installer = Join-Path "Output" "SetupForTeraterm.exe"
+          if (-not (Test-Path $installer)) {
+            throw "Installer executable not found at $installer"
+          }
+
+          $versionedInstaller = Join-Path "Output" "SetupForTeraterm_$tag.exe"
+          Copy-Item -Path $installer -Destination $versionedInstaller -Force
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- ensure the release ZIP archive uses the tag name so upload and release steps can find it
- copy the generated installer to a versioned filename that matches the expected release artifact
- fail fast if the installer executable is missing before attempting to copy it

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69189ab77658832c808b39facf0b969b)