### PR TITLE
Implement credential-aware launcher per v3 plan

### DIFF
--- a/ForTeraterm/ttl_renderer.py
+++ b/ForTeraterm/ttl_renderer.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
 from .storage import CommandSet, Profile
+
+
+ALLOWED_AUTH_TYPES = {"password", "keyboard-interactive", "publickey"}
 
 
 @dataclass
@@ -32,19 +36,31 @@ class TTLRenderer:
             raise ValueError("Host and user are required")
         if ctx.port <= 0:
             raise ValueError("Port must be positive")
-        if ctx.auth_type not in {"password", "keyboard-interactive", "publickey"}:
+        if ctx.auth_type not in ALLOWED_AUTH_TYPES:
             raise ValueError("Unsupported auth_type")
+        if not ctx.commands:
+            raise ValueError("At least one command is required")
         for cmd in ctx.commands:
             if "\n" in cmd or "\r" in cmd:
                 raise ValueError("Commands must be single-line")
             if cmd.strip() == "":
                 raise ValueError("Commands cannot be empty")
+            if re.search(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", cmd):
+                raise ValueError("Commands contain control characters")
+        if ctx.password and ("\n" in ctx.password or "\r" in ctx.password):
+            raise ValueError("Password cannot contain newlines")
 
     def validate_output(self, ttl_content: str) -> None:
-        if "connect" not in ttl_content:
+        lowered = ttl_content.lower()
+        if "connect" not in lowered:
             raise ValueError("TTL script must call connect")
-        if not ttl_content.strip().lower().endswith("end"):
+        if not lowered.strip().endswith("end"):
             raise ValueError("TTL script must end with 'end'")
+        if re.search(r'sendln\s+"\s*"', ttl_content, re.IGNORECASE):
+            raise ValueError("sendln statements must not be empty")
+
+    def _escape(self, value: str) -> str:
+        return value.replace('"', '""')
 
     def render(self, profile: Profile, command_set: CommandSet, password: Optional[str]) -> str:
         ctx = TTLContext(
@@ -57,26 +73,21 @@ class TTLRenderer:
         )
         self.validate_context(ctx)
         template_path = self.template_root / "ttl" / "v1" / "basic.ttl.j2"
-        escaped_commands = []
-        for cmd in ctx.commands:
-            escaped = cmd.replace('"', '""')
-            escaped_commands.append(f'sendln "{escaped}"')
-        commands_block = "\n".join(escaped_commands)
+        template_text = template_path.read_text(encoding="utf-8")
+        commands_block = [self._escape(cmd) for cmd in ctx.commands]
         passwd_flag = ""
         if ctx.password:
-            escaped = ctx.password.replace('"', '""')
-            passwd_flag = f" /passwd=\\\"{escaped}\\\""
-        template_text = template_path.read_text(encoding="utf-8")
+            passwd_flag = f" /passwd=\\\"{self._escape(ctx.password)}\\\""
         ttl_content = template_text.format(
             user=ctx.user,
             host=ctx.host,
             port=ctx.port,
             auth_type=ctx.auth_type,
             passwd_flag=passwd_flag,
-            commands_block=commands_block,
+            commands_block="\n".join(f'sendln "{cmd}"' for cmd in commands_block),
         )
         self.validate_output(ttl_content)
         return ttl_content
 
 
-__all__ = ["TTLContext", "TTLRenderer"]
+__all__ = ["TTLContext", "TTLRenderer", "ALLOWED_AUTH_TYPES"]

--- a/ForTeraterm/ui/credential_dialog.py
+++ b/ForTeraterm/ui/credential_dialog.py
@@ -1,0 +1,64 @@
+"""Dialog for registering or updating credentials via keyring."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox
+
+import customtkinter as ctk
+
+from ..credential_store import CredentialStore
+
+
+class CredentialDialog(ctk.CTkToplevel):
+    def __init__(self, master: ctk.CTk, cred_store: CredentialStore) -> None:
+        super().__init__(master)
+        self.title("New Credential")
+        self.resizable(False, False)
+        self.grab_set()
+        self.cred_store = cred_store
+        self.cred_ref: str | None = None
+        self._build_form()
+
+    def _build_form(self) -> None:
+        body = ctk.CTkFrame(self)
+        body.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
+
+        ctk.CTkLabel(body, text="Label").grid(row=0, column=0, sticky=tk.W, padx=4, pady=4)
+        self.label_entry = ctk.CTkEntry(body)
+        self.label_entry.grid(row=0, column=1, sticky=tk.EW, padx=4, pady=4)
+
+        ctk.CTkLabel(body, text="Username (optional)").grid(row=1, column=0, sticky=tk.W, padx=4, pady=4)
+        self.user_entry = ctk.CTkEntry(body)
+        self.user_entry.grid(row=1, column=1, sticky=tk.EW, padx=4, pady=4)
+
+        ctk.CTkLabel(body, text="Password / Passphrase").grid(row=2, column=0, sticky=tk.W, padx=4, pady=4)
+        self.secret_entry = ctk.CTkEntry(body, show="*")
+        self.secret_entry.grid(row=2, column=1, sticky=tk.EW, padx=4, pady=4)
+
+        note = "Credentials are stored via OS keyring" if not self.cred_store.restricted else "Credential storage unavailable"
+        ctk.CTkLabel(body, text=note).grid(row=3, column=0, columnspan=2, sticky=tk.W, padx=4, pady=(4, 12))
+
+        button_frame = ctk.CTkFrame(self)
+        button_frame.pack(fill=tk.X, padx=12, pady=(0, 12))
+        ctk.CTkButton(button_frame, text="Save", command=self._on_save).pack(side=tk.RIGHT, padx=4)
+        ctk.CTkButton(button_frame, text="Cancel", command=self.destroy).pack(side=tk.RIGHT, padx=4)
+
+        body.grid_columnconfigure(1, weight=1)
+
+    def _on_save(self) -> None:
+        label = self.label_entry.get().strip()
+        secret = self.secret_entry.get().strip()
+        username = self.user_entry.get().strip() or None
+        if not label or not secret:
+            messagebox.showerror("Error", "Label and secret are required")
+            return
+        try:
+            self.cred_ref = self.cred_store.register(label, username, secret)
+        except Exception as exc:  # pragma: no cover - UI surface
+            messagebox.showerror("Error", str(exc))
+            return
+        self.destroy()
+
+
+__all__ = ["CredentialDialog"]

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -34,8 +34,13 @@ def test_profile_and_history_roundtrip(tmp_path: Path) -> None:
 
     profiles = db.list_profiles()
     assert len(profiles) == 1
-    history = db.list_history_for_profile(profile_id)
+    history = db.list_history_for_profile(profile_id, result_filter="success")
     assert len(history) == 1
+    filtered = db.list_history_for_profile(profile_id, result_filter="failed")
+    assert filtered == []
     exported = db.export_data()
     assert exported["schema_version"] == 1
+    assert exported["profiles"][0]["command_set_ids"] == ["cmd:test"]
+    assert "exported_at" in exported
+    assert db.list_command_sets()
     db.close()

--- a/tests/test_ttl_renderer.py
+++ b/tests/test_ttl_renderer.py
@@ -46,3 +46,18 @@ def test_invalid_command_with_newline_raises(tmp_path: Path) -> None:
     cs.commands = ["bad\ncommand"]
     with pytest.raises(ValueError):
         renderer(tmp_path).render(sample_profile(), cs, password="secret")
+
+
+def test_empty_commands_raise(tmp_path: Path) -> None:
+    cs = sample_command_set()
+    cs.commands = []
+    with pytest.raises(ValueError):
+        renderer(tmp_path).render(sample_profile(), cs, password="secret")
+
+
+def test_password_and_command_are_escaped(tmp_path: Path) -> None:
+    cs = sample_command_set()
+    cs.commands = ['echo "hello"']
+    ttl = renderer(tmp_path).render(sample_profile(), cs, password='p"ass')
+    assert '/passwd=\\"p""ass\\"' in ttl
+    assert 'sendln "echo ""hello"""' in ttl


### PR DESCRIPTION
## Summary
- add stricter TTL validation/rendering with escaped commands and password flags
- expand datastore schema helpers, export format, and history filtering
- update UI with credential dialog, profile credential selection, and history filters/re-run support

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691efea9ce84832cb5afc8cc9b33e8b9)