### PR TITLE
Fix test annotations for Python 3.9 compatibility

### DIFF
--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import keyring
 from keyring.backend import KeyringBackend
 


### PR DESCRIPTION
## Summary
- add postponed evaluation of annotations in the credential store tests to allow Python 3.9 execution

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692068f14300832c85d40b254f8338bf)