### PR TITLE
Close temporary TTL files before invoking Tera Term

### DIFF
--- a/ForTeraterm/launcher.py
+++ b/ForTeraterm/launcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -87,7 +88,9 @@ class Launcher:
         return LaunchResult(result=result, error_code=error_code, wlog_path=wlog_path or Path(""))
 
     def _write_ttl(self, content: str) -> Path:
-        ttl_file = Path(tempfile.mkstemp(prefix="tt-launch-", suffix=".ttl")[1])
+        fd, path_str = tempfile.mkstemp(prefix="tt-launch-", suffix=".ttl")
+        os.close(fd)
+        ttl_file = Path(path_str)
         ttl_file.write_text(content, encoding="utf-8")
         return ttl_file
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ForTeraterm.launcher import Launcher
+from ForTeraterm.storage import DataStore
+from ForTeraterm.ttl_renderer import TTLRenderer
+
+
+@pytest.fixture
+def launcher(tmp_path: Path) -> Launcher:
+    renderer = TTLRenderer(Path(__file__).parents[1] / "templates")
+    storage = DataStore(tmp_path / "db.sqlite")
+    launcher = Launcher(renderer, storage, stub_mode=True)
+    yield launcher
+    storage.close()
+
+
+def test_write_ttl_closes_tempfile_handle(monkeypatch: pytest.MonkeyPatch, launcher: Launcher, tmp_path: Path) -> None:
+    recorded: dict[str, int] = {}
+    temp_path = tmp_path / "locked.ttl"
+
+    def fake_mkstemp(prefix: str, suffix: str):
+        fd = os.open(temp_path, os.O_CREAT | os.O_RDWR)
+        recorded["fd"] = fd
+        return fd, str(temp_path)
+
+    monkeypatch.setattr(tempfile, "mkstemp", fake_mkstemp)
+
+    ttl_path = launcher._write_ttl("sample")
+    assert ttl_path == temp_path
+
+    with pytest.raises(OSError):
+        os.close(recorded["fd"])


### PR DESCRIPTION
## Summary
- close the mkstemp file descriptor before writing TTL files so the Tera Term macro file is not locked by our process
- add a regression test to confirm the temporary TTL handle is closed after creation

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db5fca308832c923c5ddd0861b707)