### PR TITLE
Add theme and font customization with persisted settings

### DIFF
--- a/ForTeraterm/launcher.py
+++ b/ForTeraterm/launcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -87,7 +88,9 @@ class Launcher:
         return LaunchResult(result=result, error_code=error_code, wlog_path=wlog_path or Path(""))
 
     def _write_ttl(self, content: str) -> Path:
-        ttl_file = Path(tempfile.mkstemp(prefix="tt-launch-", suffix=".ttl")[1])
+        fd, path_str = tempfile.mkstemp(prefix="tt-launch-", suffix=".ttl")
+        os.close(fd)
+        ttl_file = Path(path_str)
         ttl_file.write_text(content, encoding="utf-8")
         return ttl_file
 

--- a/ForTeraterm/ui/settings_dialog.py
+++ b/ForTeraterm/ui/settings_dialog.py
@@ -1,0 +1,90 @@
+"""Dialog for adjusting launcher appearance and font settings."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox
+
+import customtkinter as ctk
+
+from ..storage import AppSettings
+
+
+class SettingsDialog(ctk.CTkToplevel):
+    def __init__(
+        self,
+        master: ctk.CTk,
+        current: AppSettings,
+        appearance_modes: list[str],
+        color_themes: list[str],
+        font_families: list[str],
+    ) -> None:
+        super().__init__(master)
+        self.title("Settings")
+        self.resizable(False, False)
+        self.grab_set()
+        self.result: AppSettings | None = None
+        self.current = current
+        self.appearance_modes = appearance_modes
+        self.color_themes = color_themes
+        self.font_families = font_families
+        self.preview_font = ctk.CTkFont(family=current.font_family, size=current.font_size)
+
+        self._build_form()
+
+    def _build_form(self) -> None:
+        body = ctk.CTkFrame(self)
+        body.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
+
+        ctk.CTkLabel(body, text="Appearance", font=self.preview_font).grid(row=0, column=0, sticky=tk.W, padx=4, pady=4)
+        self.appearance_var = tk.StringVar(value=self.current.appearance_mode)
+        ctk.CTkOptionMenu(body, variable=self.appearance_var, values=self.appearance_modes, font=self.preview_font).grid(
+            row=0, column=1, sticky=tk.EW, padx=4, pady=4
+        )
+
+        ctk.CTkLabel(body, text="Color Theme", font=self.preview_font).grid(row=1, column=0, sticky=tk.W, padx=4, pady=4)
+        self.theme_var = tk.StringVar(value=self.current.color_theme)
+        ctk.CTkOptionMenu(body, variable=self.theme_var, values=self.color_themes, font=self.preview_font).grid(
+            row=1, column=1, sticky=tk.EW, padx=4, pady=4
+        )
+
+        ctk.CTkLabel(body, text="Font Family", font=self.preview_font).grid(row=2, column=0, sticky=tk.W, padx=4, pady=4)
+        self.font_family_var = tk.StringVar(value=self.current.font_family)
+        ctk.CTkOptionMenu(body, variable=self.font_family_var, values=self.font_families, font=self.preview_font).grid(
+            row=2, column=1, sticky=tk.EW, padx=4, pady=4
+        )
+
+        ctk.CTkLabel(body, text="Font Size", font=self.preview_font).grid(row=3, column=0, sticky=tk.W, padx=4, pady=4)
+        self.font_size_var = tk.StringVar(value=str(self.current.font_size))
+        self.font_size_entry = ctk.CTkEntry(body, textvariable=self.font_size_var, width=80, font=self.preview_font)
+        self.font_size_entry.grid(row=3, column=1, sticky=tk.EW, padx=4, pady=4)
+
+        button_frame = ctk.CTkFrame(self)
+        button_frame.pack(fill=tk.X, padx=12, pady=(0, 12))
+        ctk.CTkButton(button_frame, text="Save", command=self._on_save, font=self.preview_font).pack(side=tk.RIGHT, padx=4)
+        ctk.CTkButton(button_frame, text="Cancel", command=self.destroy, font=self.preview_font).pack(side=tk.RIGHT, padx=4)
+
+        for i in range(2):
+            body.grid_columnconfigure(i, weight=1)
+
+    def _on_save(self) -> None:
+        size_text = self.font_size_var.get().strip()
+        try:
+            size = int(size_text)
+        except ValueError:
+            messagebox.showerror("Invalid size", "Font size must be a number")
+            return
+        if size <= 6:
+            messagebox.showerror("Invalid size", "Font size must be greater than 6")
+            return
+
+        self.result = AppSettings(
+            appearance_mode=self.appearance_var.get(),
+            color_theme=self.theme_var.get(),
+            font_family=self.font_family_var.get(),
+            font_size=size,
+        )
+        self.destroy()
+
+
+__all__ = ["SettingsDialog"]

--- a/PROJECT_PLANS.md
+++ b/PROJECT_PLANS.md
@@ -1,0 +1,18 @@
+# Project Plans
+
+Pragmatic expansions that deliver clear operator value without bloating the launcher:
+
+1. **Profile portability (export/import with secrets stripping)**
+   - Allow exporting profiles/command sets without credentials, plus selective import with conflict resolution. Saves time when sharing vetted settings across teams while avoiding secret leaks.
+
+2. **Connection health checks and retry policy**
+   - Add optional pre-flight ping/port checks and configurable retry intervals. Reduces failed runs from typos or transient network blips.
+
+3. **Audit-friendly history view**
+   - Extend history filtering with date ranges and CSV export. Makes it usable for audits and quick incident reviews rather than a basic log list.
+
+4. **Credential usage guardrails**
+   - Warn when using stale credentials, and allow per-profile “require password every time” toggles. Prevents silent reuse of outdated secrets.
+
+5. **Quick-connect scratchpad**
+   - Lightweight one-off connection launcher that never writes to the database. Avoids cluttering profiles when testing temporary hosts.

--- a/execplans/001-theme-font.md
+++ b/execplans/001-theme-font.md
@@ -1,0 +1,66 @@
+# Add theme and font customization
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. Maintain this document in accordance with `.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+Users want control over the launcher’s look and feel. After this change, they can choose a color theme (light/dark/system with CustomTkinter color palettes) and a preferred font family/size. Preferences must persist across restarts so the UI opens with the last selected style.
+
+## Progress
+
+- [x] (2025-01-10 00:00Z) Draft initial plan.
+- [x] (2025-01-10 00:20Z) Implement settings persistence with schema update.
+- [x] (2025-01-10 00:40Z) Add UI to view/update theme and font preferences.
+- [x] (2025-01-10 00:55Z) Apply preferences to the main window widgets and validate behavior.
+
+## Surprises & Discoveries
+
+- None yet.
+
+## Decision Log
+
+- Decision: Store preferences in SQLite rather than a separate config file to keep settings alongside existing profile data and reuse the datastore lifecycle.
+  Rationale: Reduces new dependencies and keeps persistence centralized.
+  Date/Author: 2025-01-10 / Assistant
+
+## Outcomes & Retrospective
+
+- Preferences persist via SQLite and drive the launcher’s appearance and fonts on startup. UI toggles apply immediately without breaking profile selection or history filters.
+
+## Context and Orientation
+
+The launcher UI lives in `ForTeraterm/ui/main_window.py` and starts from `main.py`. Persistent data is handled via `ForTeraterm/storage.py`, which owns SQLite schema creation/migration. There is currently no settings persistence. CustomTkinter controls are used throughout the UI, with some raw Tk widgets for list boxes and text areas.
+
+## Plan of Work
+
+Expand the SQLite schema to include a `preferences` table and expose helper methods on `DataStore` to load and save an `AppSettings` dataclass (appearance mode, color theme, font family, font size). Migrate existing databases to the new schema version.
+
+Create a new `SettingsDialog` in `ForTeraterm/ui/settings_dialog.py` that surfaces dropdowns for appearance mode and color theme, plus inputs for font family and size (with sane defaults and validation). Add a “Settings” entry point in the main window (button near the status bar) to open the dialog. When the dialog is confirmed, persist the settings via the datastore and immediately apply them to the UI.
+
+Introduce helper methods on `MainWindow` to build and update shared `CTkFont`/Tk font instances and reconfigure existing widgets. Apply appearance/color themes via `customtkinter.set_appearance_mode` and `set_default_color_theme` before constructing widgets so initial render respects stored settings.
+
+## Concrete Steps
+
+1. Update `ForTeraterm/storage.py` to bump schema version, create/migrate a `preferences` table, and add `AppSettings` plus load/save helpers.
+2. Add `ForTeraterm/ui/settings_dialog.py` implementing the dialog UI and returning updated settings.
+3. Modify `ForTeraterm/ui/main_window.py` to load settings at startup, apply appearance/color themes, construct shared fonts, add a Settings button, and wire dialog results to persistence and live UI updates.
+4. Add tests in `tests/` validating settings persistence and application (e.g., storing/loading defaults, applying updates triggers theme/font change calls where feasible).
+
+## Validation and Acceptance
+
+- Launching the app after saving preferences should open with the chosen appearance mode/color theme and the selected font reflected in labels/buttons/list boxes.
+- Database migration from a pre-existing file succeeds, and loading settings returns defaults when no preferences are saved.
+- Automated tests pass (`pytest -q`).
+
+## Idempotence and Recovery
+
+Schema migrations are additive and versioned; rerunning the app safely ensures the `preferences` table exists. The settings dialog writes preferences atomically through the datastore; reopening the dialog shows the last saved values. If invalid font size is entered, validation prevents saving and keeps previous values intact.
+
+## Artifacts and Notes
+
+- None yet.
+
+## Interfaces and Dependencies
+
+- `ForTeraterm/storage.py` will expose an `AppSettings` dataclass with fields `appearance_mode: str`, `color_theme: str`, `font_family: str`, `font_size: int`, plus `load_settings()` and `save_settings(settings: AppSettings)` methods.
+- `ForTeraterm/ui/settings_dialog.py` will expose `SettingsDialog(ctk.CTkToplevel)` with properties to return the chosen `AppSettings`.

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from ForTeraterm.storage import CommandSet, DataStore, HistoryRecord, Profile
+from ForTeraterm.storage import AppSettings, CommandSet, DataStore, HistoryRecord, Profile
 
 
 def test_profile_and_history_roundtrip(tmp_path: Path) -> None:
@@ -40,8 +40,30 @@ def test_profile_and_history_roundtrip(tmp_path: Path) -> None:
     filtered = db.list_history_for_profile(profile_id, result_filter="failed")
     assert filtered == []
     exported = db.export_data()
-    assert exported["schema_version"] == 2
+    assert exported["schema_version"] == 3
     assert exported["profiles"][0]["command_set_ids"] == ["cmd:test"]
     assert "exported_at" in exported
     assert db.list_command_sets()
     db.close()
+
+
+def test_settings_defaults_and_persistence(tmp_path: Path) -> None:
+    db_path = tmp_path / "settings.db"
+    first = DataStore(db_path)
+    defaults = first.load_settings()
+    assert defaults.appearance_mode == "system"
+    assert defaults.color_theme == "blue"
+    assert defaults.font_family == "Arial"
+    assert defaults.font_size == 12
+
+    new_settings = AppSettings(
+        appearance_mode="dark",
+        color_theme="green",
+        font_family="Consolas",
+        font_size=14,
+    )
+    first.save_settings(new_settings)
+    first.close()
+
+    reloaded = DataStore(db_path).load_settings()
+    assert reloaded == new_settings

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ForTeraterm.launcher import Launcher
+from ForTeraterm.storage import DataStore
+from ForTeraterm.ttl_renderer import TTLRenderer
+
+
+@pytest.fixture
+def launcher(tmp_path: Path) -> Launcher:
+    renderer = TTLRenderer(Path(__file__).parents[1] / "templates")
+    storage = DataStore(tmp_path / "db.sqlite")
+    launcher = Launcher(renderer, storage, stub_mode=True)
+    yield launcher
+    storage.close()
+
+
+def test_write_ttl_closes_tempfile_handle(monkeypatch: pytest.MonkeyPatch, launcher: Launcher, tmp_path: Path) -> None:
+    recorded: dict[str, int] = {}
+    temp_path = tmp_path / "locked.ttl"
+
+    def fake_mkstemp(prefix: str, suffix: str):
+        fd = os.open(temp_path, os.O_CREAT | os.O_RDWR)
+        recorded["fd"] = fd
+        return fd, str(temp_path)
+
+    monkeypatch.setattr(tempfile, "mkstemp", fake_mkstemp)
+
+    ttl_path = launcher._write_ttl("sample")
+    assert ttl_path == temp_path
+
+    with pytest.raises(OSError):
+        os.close(recorded["fd"])


### PR DESCRIPTION
## Summary
- add a preferences table with AppSettings persistence for appearance mode, color theme, and font
- introduce a settings dialog and apply chosen fonts/themes across the main window
- document future roadmap ideas in PROJECT_PLANS.md

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db5fca308832c923c5ddd0861b707)