### PR TITLE
Add Tera Term integration with presets and tagging

### DIFF
--- a/ForTeraterm/ui/settings_dialog.py
+++ b/ForTeraterm/ui/settings_dialog.py
@@ -29,6 +29,10 @@ class SettingsDialog(ctk.CTkToplevel):
         self.color_themes = color_themes
         self.font_families = font_families
         self.preview_font = ctk.CTkFont(family=current.font_family, size=current.font_size)
+        self.search_var = tk.StringVar()
+        self.teraterm_var = tk.StringVar(value=current.teraterm_path)
+        self.use_stub_var = tk.BooleanVar(value=current.use_stub)
+        self._settings_rows: list[tuple[ctk.CTkLabel, tk.Widget, str]] = []
 
         self._build_form()
 
@@ -36,28 +40,36 @@ class SettingsDialog(ctk.CTkToplevel):
         body = ctk.CTkFrame(self)
         body.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
 
-        ctk.CTkLabel(body, text="Appearance", font=self.preview_font).grid(row=0, column=0, sticky=tk.W, padx=4, pady=4)
+        search_frame = ctk.CTkFrame(body)
+        search_frame.grid(row=0, column=0, columnspan=2, sticky=tk.EW, padx=4, pady=(0, 8))
+        ctk.CTkLabel(search_frame, text="Search", font=self.preview_font).pack(side=tk.LEFT, padx=4)
+        search_entry = ctk.CTkEntry(search_frame, textvariable=self.search_var, font=self.preview_font)
+        search_entry.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=4)
+        search_entry.bind("<KeyRelease>", lambda _event: self._filter_settings())
+
         self.appearance_var = tk.StringVar(value=self.current.appearance_mode)
-        ctk.CTkOptionMenu(body, variable=self.appearance_var, values=self.appearance_modes, font=self.preview_font).grid(
-            row=0, column=1, sticky=tk.EW, padx=4, pady=4
-        )
+        appearance_menu = ctk.CTkOptionMenu(body, variable=self.appearance_var, values=self.appearance_modes, font=self.preview_font)
+        self._add_row(body, 1, "Appearance", appearance_menu, keywords="appearance theme mode")
 
-        ctk.CTkLabel(body, text="Color Theme", font=self.preview_font).grid(row=1, column=0, sticky=tk.W, padx=4, pady=4)
         self.theme_var = tk.StringVar(value=self.current.color_theme)
-        ctk.CTkOptionMenu(body, variable=self.theme_var, values=self.color_themes, font=self.preview_font).grid(
-            row=1, column=1, sticky=tk.EW, padx=4, pady=4
-        )
+        theme_menu = ctk.CTkOptionMenu(body, variable=self.theme_var, values=self.color_themes, font=self.preview_font)
+        self._add_row(body, 2, "Color Theme", theme_menu, keywords="theme color")
 
-        ctk.CTkLabel(body, text="Font Family", font=self.preview_font).grid(row=2, column=0, sticky=tk.W, padx=4, pady=4)
         self.font_family_var = tk.StringVar(value=self.current.font_family)
-        ctk.CTkOptionMenu(body, variable=self.font_family_var, values=self.font_families, font=self.preview_font).grid(
-            row=2, column=1, sticky=tk.EW, padx=4, pady=4
-        )
+        font_menu = ctk.CTkOptionMenu(body, variable=self.font_family_var, values=self.font_families, font=self.preview_font)
+        self._add_row(body, 3, "Font Family", font_menu, keywords="font family typeface")
 
-        ctk.CTkLabel(body, text="Font Size", font=self.preview_font).grid(row=3, column=0, sticky=tk.W, padx=4, pady=4)
         self.font_size_var = tk.StringVar(value=str(self.current.font_size))
-        self.font_size_entry = ctk.CTkEntry(body, textvariable=self.font_size_var, width=80, font=self.preview_font)
-        self.font_size_entry.grid(row=3, column=1, sticky=tk.EW, padx=4, pady=4)
+        self.font_size_entry = ctk.CTkEntry(body, textvariable=self.font_size_var, width=120, font=self.preview_font)
+        self._add_row(body, 4, "Font Size", self.font_size_entry, keywords="font size")
+
+        teraterm_entry = ctk.CTkEntry(body, textvariable=self.teraterm_var, font=self.preview_font)
+        self._add_row(body, 5, "Tera Term Path", teraterm_entry, keywords="teraterm path executable client")
+
+        stub_checkbox = ctk.CTkCheckBox(body, text="Use stub mode (no real Tera Term)", variable=self.use_stub_var, font=self.preview_font)
+        self._add_row(body, 6, "Stub Mode", stub_checkbox, keywords="stub simulate")
+
+        self._filter_settings()
 
         button_frame = ctk.CTkFrame(self)
         button_frame.pack(fill=tk.X, padx=12, pady=(0, 12))
@@ -66,6 +78,31 @@ class SettingsDialog(ctk.CTkToplevel):
 
         for i in range(2):
             body.grid_columnconfigure(i, weight=1)
+
+    def _add_row(
+        self,
+        frame: ctk.CTkFrame,
+        row: int,
+        label: str,
+        widget: tk.Widget,
+        *,
+        keywords: str,
+    ) -> None:
+        lbl = ctk.CTkLabel(frame, text=label, font=self.preview_font)
+        lbl.grid(row=row, column=0, sticky=tk.W, padx=4, pady=4)
+        widget.grid(row=row, column=1, sticky=tk.EW, padx=4, pady=4)
+        self._settings_rows.append((lbl, widget, keywords.lower()))
+
+    def _filter_settings(self) -> None:
+        term = (self.search_var.get() or "").lower()
+        for label, widget, keywords in self._settings_rows:
+            match = not term or term in keywords or term in label.cget("text").lower()
+            if match:
+                label.grid()
+                widget.grid()
+            else:
+                label.grid_remove()
+                widget.grid_remove()
 
     def _on_save(self) -> None:
         size_text = self.font_size_var.get().strip()
@@ -83,6 +120,8 @@ class SettingsDialog(ctk.CTkToplevel):
             color_theme=self.theme_var.get(),
             font_family=self.font_family_var.get(),
             font_size=size,
+            teraterm_path=self.teraterm_var.get().strip(),
+            use_stub=bool(self.use_stub_var.get()),
         )
         self.destroy()
 

--- a/ForTeraterm/ui/terminal_window.py
+++ b/ForTeraterm/ui/terminal_window.py
@@ -25,11 +25,26 @@ class TerminalWindow(ctk.CTkToplevel):
         self.title("Terminal")
         self.geometry("760x460")
         self.resizable(True, True)
-        self.body_font = font
+
+        if isinstance(font, ctk.CTkFont):
+            self.body_font = font
+            self.tk_font = font
+        else:
+            actual = font.actual()
+            self.body_font = ctk.CTkFont(
+                family=actual.get("family"),
+                size=int(actual.get("size", 0) or 12),
+                weight=actual.get("weight"),
+                slant=actual.get("slant"),
+                underline=bool(actual.get("underline")),
+                overstrike=bool(actual.get("overstrike")),
+            )
+            self.tk_font = font
+
         self.on_cancel = on_cancel
         self.on_reconnect = on_reconnect
         self.live = live
-        self.text = tk.Text(self, state="disabled", font=self.body_font, bg="#111", fg="#e5e5e5")
+        self.text = tk.Text(self, state="disabled", font=self.tk_font, bg="#111", fg="#e5e5e5")
         self.text.pack(fill=tk.BOTH, expand=True, padx=8, pady=(8, 2))
         controls = ctk.CTkFrame(self)
         controls.pack(fill=tk.X, padx=8, pady=(0, 8))

--- a/execplans/004-teraterm-presets-tags.md
+++ b/execplans/004-teraterm-presets-tags.md
@@ -1,0 +1,90 @@
+# Enable real Tera Term sessions, presets, settings search, and tagging
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. This plan must be maintained in accordance with .agent/PLANS.md.
+
+## Purpose / Big Picture
+
+Users should be able to launch real server sessions through Tera Term directly from the launcher, automatically run predefined command sets (including a default health-check set), continue interacting with the opened terminal, quickly search settings, and organize profiles with tags. The change should let a new user create or pick a profile, connect via Tera Term, see preset commands run, keep the session open for manual use, search settings entries, and filter profiles by tags.
+
+## Progress
+
+- [x] (2025-12-04 16:40Z) Drafted initial ExecPlan describing goals and approach.
+- [x] (2025-12-04 17:05Z) Expanded schema and settings to support tags plus Tera Term path/stub flags with migrations and defaults.
+- [x] (2025-12-04 17:18Z) Added Tera Term launch path with real invocation/tailing, seeded system health preset, and session preset selector with tagging filters in the main/profile UI.
+- [x] (2025-12-04 17:25Z) Implemented searchable settings dialog with new fields and refreshed UI wiring; ran automated tests.
+- [ ] (pending) Final validation/retrospective updates after any additional manual checks.
+
+## Surprises & Discoveries
+
+- Duplicate `_open_settings` and `_rebuild_ui` definitions existed in the main window; removed the redundant block to keep rebuild logic consistent.
+- Falling back to stub mode when no Tera Term path is configured avoids breaking connects while still surfacing the missing executable in the status stream.
+
+## Decision Log
+
+- Decision: Seed a shared "System Health" command set and allow session-level preset selection instead of duplicating commands per profile.
+  Rationale: Ensures the required basic CPU/memory/disk checks are always available and reusable without editing each profile.
+  Date/Author: 2025-12-04 / agent
+- Decision: When Tera Term path is absent, automatically fall back to stub streaming while emitting a warning.
+  Rationale: Keeps Connect usable in environments without Tera Term while still guiding users to configure the executable for real sessions.
+  Date/Author: 2025-12-04 / agent
+
+## Outcomes & Retrospective
+
+- Implemented tagging, preset seeding/selection, real Tera Term launch support, and searchable settings. Automated tests (`pytest -q`) pass. Manual retrospective pending further UI verification.
+
+## Context and Orientation
+
+Relevant code lives in `ForTeraterm/`:
+- `launcher.py` handles TTL rendering and session launching; currently stubbed (`stub_mode=True`) and lacks real Tera Term invocation.
+- `ttl_renderer.py` renders TTL scripts from templates in `templates/ttl/v1/basic.ttl.j2` using profile and command set data.
+- `storage.py` stores `Profile`, `CommandSet`, `AppSettings`, and history in SQLite. No tag support exists; settings are limited to appearance/font only.
+- `ui/main_window.py` builds the main UI with profile list, history, connect flow, and uses `Launcher` in stub mode. Profiles search by name/host only; no tag filtering.
+- `ui/profile_dialog.py` creates/edits profiles and command sets. No tagging or preset selection beyond per-profile command set.
+- `ui/settings_dialog.py` shows a small set of appearance/font settings with no search/filtering.
+- `ui/terminal_window.py` shows live output or log files; it is non-interactive and follows CustomTkinter font handling.
+
+The goal is to extend these areas to support tags, preset command selection (including a seeded system-info set), searchable settings, and a real Tera Term execution path that keeps the terminal usable after the preset commands run.
+
+## Plan of Work
+
+1. **Schema and settings expansion**: Add tag support to profiles and extend app settings to store the Tera Term executable path and a flag to allow real execution (falling back to stub mode for tests). Implement migrations to bump the schema version and persist tags (likely as a JSON/text column) plus the new settings fields. Update data classes, caching, import/export, and any search functions to include tags.
+2. **Preset seeding and selection**: Introduce a built-in command set for system health (CPU/memory/disk basics) seeded at startup if missing. Allow users to pick which preset to run at connect time (defaulting to the profile’s command set), exposing available command sets in the main UI and profile dialog where appropriate.
+3. **Real Tera Term launch path**: Enhance `Launcher` to execute Tera Term when `stub_mode` is False by invoking the configured executable with generated TTL and optional wlog output. Ensure the session window stays open after presets by avoiding auto-close TTL macros and by not destroying the live `TerminalWindow`. Preserve asynchronous callbacks and history recording, and make stub mode the default for tests.
+4. **UI for settings search and tagging**: Add tag entry/selector to the profile dialog and display tags in the profile list/details. Provide tag-based filtering in the main window (e.g., a search field or dropdown). Enhance the settings dialog with a search box that highlights or filters available settings entries (appearance, theme, font, teraterm path, stub toggle) to satisfy the search requirement.
+5. **Validation**: Update or add tests for migrations, default command set seeding, and launcher behavior (stub path). Document manual validation steps in this plan. Run the existing pytest suite and any new targeted tests.
+
+## Concrete Steps
+
+- Work in the repository root `/workspace/ForTeraterm`.
+- Update `storage.py` schema version, migrations, data classes, and search/filter methods to include `tags` plus new settings fields; adjust import/export accordingly.
+- Extend `AppSettings` to include `teraterm_path` and `use_stub` (or similar) defaults; update load/save and settings dialog to edit them.
+- Seed a default command set (system info) during application startup (e.g., DataStore helper invoked by MainWindow) and expose command set choices in the connect flow.
+- Modify `Launcher` to support real execution via `subprocess.Popen` when stub mode is disabled, passing TTL file and wlog path, and keep terminal windows open while recording history.
+- Enhance `MainWindow` and `ProfileDialog` to manage tags and command set selection per session; show tags in lists and filters.
+- Add a search field in `SettingsDialog` that filters/highlights settings entries and includes new settings fields.
+- Update `terminal_window.py` if needed to support continued viewing after preset commands (e.g., status updates, reconnect behavior).
+- Write or adjust tests in `tests/` for new behavior where practical; keep stub mode default for automated tests.
+- Run `pytest -q` and verify UI flows manually if possible; record outcomes below.
+
+## Validation and Acceptance
+
+After implementation:
+- Start the app (`python main.py` or equivalent) and verify that settings include Tera Term path/stub toggle and can be searched via a search box (typing “font” narrows to font controls, typing “tera” shows the executable path).
+- Create or edit a profile with tags and select the system-info preset. In the main window, filter profiles by a tag and confirm the list updates. Click Connect: Tera Term should launch when a path is configured and stub mode disabled; otherwise, stub mode still shows streamed output. Preset commands appear in the terminal output and the session remains open for manual interaction.
+- History entries should reflect the command set used and preserve the wlog path.
+- Automated tests (`pytest -q`) pass.
+
+## Idempotence and Recovery
+
+Schema migrations should be safe to re-run. Seed logic must check for existing command sets to avoid duplicates. If Tera Term execution fails, fall back to stub mode with clear status messages. Cancelling a launch should stop the thread; TTL temp files should be cleaned up in `finally` blocks.
+
+## Artifacts and Notes
+
+- Capture any new test outputs or manual check results here after execution.
+
+## Interfaces and Dependencies
+
+- New settings fields: `AppSettings.teraterm_path: str` (path to executable) and `AppSettings.use_stub: bool` (default True for tests). Stored in `preferences` table as strings.
+- New profile field: `tags: list[str]` stored in DB as JSON/text; searchable and displayed in UI.
+- Launcher real mode: call `subprocess.Popen([teraterm_path, f"/R={ttl_file}", f"/W={wlog_path}"])` or similar; wait for completion up to timeout; stream wlog tail into UI when possible.
+

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -18,6 +18,7 @@ def test_profile_and_history_roundtrip(tmp_path: Path) -> None:
         ssh_options="",
         ttl_template_version="v1-basic",
         command_set_id=cmd_id,
+        tags=[],
     )
     profile_id = db.upsert_profile(profile)
     record = HistoryRecord(
@@ -40,7 +41,7 @@ def test_profile_and_history_roundtrip(tmp_path: Path) -> None:
     filtered = db.list_history_for_profile(profile_id, result_filter="failed")
     assert filtered == []
     exported = db.export_data()
-    assert exported["schema_version"] == 3
+    assert exported["schema_version"] == 4
     assert exported["profiles"][0]["command_set_ids"] == ["cmd:test"]
     assert "exported_at" in exported
     assert db.list_command_sets()
@@ -55,12 +56,16 @@ def test_settings_defaults_and_persistence(tmp_path: Path) -> None:
     assert defaults.color_theme == "blue"
     assert defaults.font_family == "Arial"
     assert defaults.font_size == 12
+    assert defaults.teraterm_path == ""
+    assert defaults.use_stub is True
 
     new_settings = AppSettings(
         appearance_mode="dark",
         color_theme="green",
         font_family="Consolas",
         font_size=14,
+        teraterm_path="/usr/bin/ttermpro",
+        use_stub=False,
     )
     first.save_settings(new_settings)
     first.close()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -51,6 +51,7 @@ def _create_profile_and_commands(storage: DataStore) -> tuple[Profile, CommandSe
         ssh_options="",
         ttl_template_version="v1-basic",
         command_set_id=cmd_id,
+        tags=[],
     )
     profile_id = storage.upsert_profile(profile)
     profile.id = profile_id

--- a/tests/test_ttl_renderer.py
+++ b/tests/test_ttl_renderer.py
@@ -23,6 +23,7 @@ def sample_profile() -> Profile:
         ssh_options="",
         ttl_template_version="v1-basic",
         command_set_id=1,
+        tags=[],
     )
 
 


### PR DESCRIPTION
## Summary
- extend storage schema/settings with tags, Tera Term path, stub toggle, and seed a reusable system health command set
- add UI support for tag filtering, session command presets, and searchable settings including Tera Term configuration
- enable real Tera Term invocation with wlog tailing and maintain stub fallback when the executable is missing

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930486f722c832c967151f7fbcd11a7)